### PR TITLE
Filter for quantum workflows, optionally disable "All"

### DIFF
--- a/wfe/dashboard/ck-repo-widget/widget.js
+++ b/wfe/dashboard/ck-repo-widget/widget.js
@@ -473,7 +473,7 @@ var CkRepoWidgetFilter = function () {
                 }
             }
 
-            return CkRepoWidgetConstants.kFilterAllValue;
+            return selector.values[0];
         }
     }]);
 
@@ -1873,6 +1873,14 @@ var CkRepoWdiget = function () {
                     }
 
                     table.build(data.table);
+
+                    // Apply default filters
+                    workflow.config.selector2.forEach(function (selector, i) {
+                        if (selector.values.length > 1) {
+                            let value = workflow.filter.getSelectorValue(selector);
+                            _this9._applyFilterValue(selector, value);
+                        }
+                    });
 
                     _this9._hideLoadingLayer();
                 };

--- a/wfe/dashboard/ck-repo-widget/widget.js
+++ b/wfe/dashboard/ck-repo-widget/widget.js
@@ -84,7 +84,9 @@ var CkRepoWidgetUtils = {
 
             values.sort();
 
-            values.unshift(CkRepoWidgetConstants.kFilterAllValue);
+            if (typeof selector['filter_by_all'] == "undefined" || selector['filter_by_all'] == true) {
+                values.unshift(CkRepoWidgetConstants.kFilterAllValue);
+            }
 
             selector['values'] = values;
         });


### PR DESCRIPTION
Issue: https://github.com/ctuning/ck-quantum/issues/9
Allow for selector to disable filtering by "All" with flag "filter_by_all" in selector list (that's where "name" and "key" located).
Used to filter Molecule, as described in the issue.